### PR TITLE
Implement equals()/hashCode() consistent with compareTo()

### DIFF
--- a/src/main/java/org/logicalshift/concurrent/SerialScheduledExecutorService.java
+++ b/src/main/java/org/logicalshift/concurrent/SerialScheduledExecutorService.java
@@ -15,6 +15,7 @@
  */
 package org.logicalshift.concurrent;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -318,6 +319,25 @@ public class SerialScheduledExecutorService
         }
 
         @Override
+        public int hashCode()
+        {
+            return Objects.hashCode(remainingDelayNanos);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            final SerialScheduledFuture other = (SerialScheduledFuture) obj;
+            return Objects.equal(this.remainingDelayNanos, other.remainingDelayNanos);
+        }
+
+        @Override
         public boolean cancel(boolean b)
         {
             return task.cancel(b);
@@ -397,6 +417,25 @@ public class SerialScheduledExecutorService
         {
             task = new FutureTask<Void>(runnable, null);
             remainingDelayNanos = recurringDelayNanos;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hashCode(remainingDelayNanos);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            final SerialScheduledFuture other = (SerialScheduledFuture) obj;
+            return Objects.equal(this.remainingDelayNanos, other.remainingDelayNanos);
         }
     }
 


### PR DESCRIPTION
From the JavaDoc for the compareTo method in the Comparable interface:
It is strongly recommended, but not strictly required that (x.compareTo(y)==0) == (x.equals(y)). Generally speaking, any class that implements the Comparable interface and violates this condition should clearly indicate this fact. The recommended language is "Note: this class has a natural ordering that is inconsistent with equals."
